### PR TITLE
Fix test warnings

### DIFF
--- a/tests/test_mocked_appsearch_testcase.py
+++ b/tests/test_mocked_appsearch_testcase.py
@@ -3,9 +3,8 @@
 
 """Test cases for `MockedAppSearchTestCase`."""
 
-from datetime import datetime
-
 from django.test import TestCase
+from django.utils import timezone
 from django_elastic_appsearch.test import MockedAppSearchTestCase
 
 from example.models import Car
@@ -17,17 +16,17 @@ class TestMockedAppSearchTestCase(MockedAppSearchTestCase, TestCase):
     def setUp(self, *args, **kwargs):
         """Load test data."""
         super().setUp(*args, **kwargs)
-        datetime_now = datetime.now()
+        timezone_now = timezone.now()
         car1 = Car(
             make='Toyota',
             model='Corolla',
-            year_manufactured=datetime_now
+            year_manufactured=timezone_now
         )
         car1.save()
         car2 = Car(
             make='Peugeot',
             model='307',
-            year_manufactured=datetime_now
+            year_manufactured=timezone_now
         )
         car2.save()
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -3,8 +3,7 @@
 
 """Test cases for the ORM methods."""
 
-from datetime import datetime
-
+from django.utils import timezone
 from django_elastic_appsearch import serialisers
 
 from example.models import Car
@@ -21,12 +20,12 @@ class TestORM(BaseElasticAppSearchClientTestCase):
         super().setUp()
         # Create 22 cars
         for i in range(0, 22):
-            datetime_now = datetime.now()
+            timezone_now = timezone.now()
             # Create a car
             car = Car(
                 make='Make {}'.format(i),
                 model='Model {}'.format(i),
-                year_manufactured=datetime_now
+                year_manufactured=timezone_now
             )
             car.save()
 

--- a/tests/test_serialisers.py
+++ b/tests/test_serialisers.py
@@ -3,9 +3,8 @@
 
 """Test cases for serialisers."""
 
-from datetime import datetime
-
 from django.test import TestCase
+from django.utils import timezone
 
 from example.models import Car
 from example.serialisers import CarSerialiser
@@ -17,12 +16,12 @@ class TestAppSearchSerialiser(TestCase):
     def test_app_search_serialiser(self):
         """Test the `AppSearchSerialiser`."""
 
-        datetime_now = datetime.now()
+        timezone_now = timezone.now()
         # Create a car
         car = Car(
             make='Toyota',
             model='Corolla',
-            year_manufactured=datetime_now
+            year_manufactured=timezone_now
         )
         car.save()
 
@@ -36,4 +35,4 @@ class TestAppSearchSerialiser(TestCase):
         self.assertEqual(data.get('make'), 'Toyota')
         self.assertEqual(data.get('model'), 'Corolla')
         self.assertEqual(data.get('verbose_name'), 'Toyota Corolla')
-        self.assertEqual(data.get('year_manufactured'), datetime_now)
+        self.assertEqual(data.get('year_manufactured'), timezone_now)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,12 +3,12 @@
 
 """Test cases for Django Elastic App Search settings configurations."""
 
-from datetime import datetime
 from unittest.mock import patch
 
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
 from django.test import override_settings
 
 from django_elastic_appsearch.apps import DjangoAppSearchConfig
@@ -111,12 +111,12 @@ class TestDjangoElasticAppSearchSettings(BaseElasticAppSearchClientTestCase):
         )
         # Create 22 cars
         for i in range(0, 22):
-            datetime_now = datetime.now()
+            timezone_now = timezone.now()
             # Create a car
             car = Car(
                 make='Make {}'.format(i),
                 model='Model {}'.format(i),
-                year_manufactured=datetime_now
+                year_manufactured=timezone_now
             )
             car.save()
         with patch(

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -3,9 +3,8 @@
 
 """Test cases for the queryset slicer."""
 
-from datetime import datetime
-
 from django.test import TestCase
+from django.utils import timezone
 from django_elastic_appsearch.slicer import slice_queryset
 
 from example.models import Car
@@ -18,12 +17,12 @@ class TestSlicer(TestCase):
         """Add the test cars."""
         # Create 22 cars
         for i in range(0, 22):
-            datetime_now = datetime.now()
+            timezone_now = timezone.now()
             # Create a car
             car = Car(
                 make='Make {}'.format(i),
                 model='Model {}'.format(i),
-                year_manufactured=datetime_now
+                year_manufactured=timezone_now
             )
             car.save()
 


### PR DESCRIPTION
Fix test warnings by using timezone aware `datetime` objects in the tests.