### PR TITLE
Support multiple engines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ clean-pyc: ## remove Python file artifacts
 
 lint: ## check style with flake8
 	flake8 django_elastic_appsearch tests
+	pydocstyle django_elastic_appsearch tests
 
 test: ## run tests quickly with the default Python
 	python runtests.py tests

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ mock = "*"
 flake8 = "*"
 codecov = "*"
 tox = "*"
+pydocstyle = "*"
 
 [packages]
 elastic-app-search = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "81502d210ee5b310059a056c834ec7650cee38e36834ceec363322aada7802e9"
+            "sha256": "980483b2c8328a76b11e88dfd24913f210eb006f9d4197f9ee18df152cc14ca2"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -19,6 +19,7 @@
                 "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
                 "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==3.3.1"
         },
         "certifi": {
@@ -33,6 +34,7 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "django": {
@@ -55,6 +57,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "pyjwt": {
@@ -76,6 +79,7 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.25.1"
         },
         "serpy": {
@@ -91,6 +95,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
         },
         "sqlparse": {
@@ -98,6 +103,7 @@
                 "sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0",
                 "sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==0.4.1"
         },
         "urllib3": {
@@ -105,6 +111,7 @@
                 "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
                 "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.2"
         }
     },
@@ -121,6 +128,7 @@
                 "sha256:52b5919b81842b1854196eaae5ca29679a2f2e378905c346d3ca8227c2c66080",
                 "sha256:9f8ccbeb6183c6e6cddea37592dfb0167485c1e3b13b3363bc325aa8bda3adbd"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==3.2.1"
         },
         "bump2version": {
@@ -128,6 +136,7 @@
                 "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410",
                 "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "bumpversion": {
@@ -191,12 +200,14 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "codecov": {
             "hashes": [
                 "sha256:6cde272454009d27355f9434f4e49f238c0273b216beda8472a65dc4957f473b",
-                "sha256:ba8553a82942ce37d4da92b70ffd6d54cf635fc1793ab0a7dc3fecd6ebfb3df8"
+                "sha256:ba8553a82942ce37d4da92b70ffd6d54cf635fc1793ab0a7dc3fecd6ebfb3df8",
+                "sha256:e95901d4350e99fc39c8353efa450050d2446c55bac91d90fcfd2354e19a6aef"
             ],
             "index": "pypi",
             "version": "==2.1.11"
@@ -206,6 +217,7 @@
                 "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
                 "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.4.4"
         },
         "coverage": {
@@ -280,6 +292,7 @@
                 "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030",
                 "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==3.3.1"
         },
         "distlib": {
@@ -294,6 +307,7 @@
                 "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
                 "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.16"
         },
         "filelock": {
@@ -316,6 +330,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "jeepney": {
@@ -331,6 +346,7 @@
                 "sha256:1746d3ac913d449a090caf11e9e4af00e26c3f7f7e81027872192b2398b98675",
                 "sha256:4be9cbaaaf83e61d6399f733d113ede7d1c73bc75cb6aeb64eee0f6ac39b30ea"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==21.8.0"
         },
         "mccabe": {
@@ -353,20 +369,22 @@
                 "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
                 "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.8"
         },
         "pkginfo": {
             "hashes": [
-                "sha256:a6a4ac943b496745cec21f14f021bbd869d5e9b4f6ec06918cffea5a2f4b9193",
-                "sha256:ce14d7296c673dc4c61c759a0b6c14bae34e34eb819c0017bb6ca5b7292c56e9"
+                "sha256:029a70cb45c6171c329dfc890cde0879f8c52d6f3922794796e06f577bb03db4",
+                "sha256:9fdbea6495622e022cc72c2e5e1b735218e4ffb2a2a69cde2694a6c1f16afb75"
             ],
-            "version": "==1.6.1"
+            "version": "==1.7.0"
         },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -374,6 +392,7 @@
                 "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
                 "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.10.0"
         },
         "pycodestyle": {
@@ -381,6 +400,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pycparser": {
@@ -388,13 +408,23 @@
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
                 "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
+        },
+        "pydocstyle": {
+            "hashes": [
+                "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325",
+                "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"
+            ],
+            "index": "pypi",
+            "version": "==5.1.1"
         },
         "pyflakes": {
             "hashes": [
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
         },
         "pygments": {
@@ -402,6 +432,7 @@
                 "sha256:bc9591213a8f0e0ca1a5e68a479b4887fdc3e75d0774e5c71c31920c427de435",
                 "sha256:df49d09b498e83c1a73128295860250b0b7edd4c723a32e9bc0d295c7c2ec337"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.7.4"
         },
         "pyparsing": {
@@ -409,6 +440,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "readme-renderer": {
@@ -423,6 +455,7 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.25.1"
         },
         "requests-toolbelt": {
@@ -452,13 +485,22 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.15.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
+            ],
+            "version": "==2.0.0"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tox": {
@@ -474,6 +516,7 @@
                 "sha256:4621f6823bab46a9cc33d48105753ccbea671b68bab2c50a9f0be23d4065cb5a",
                 "sha256:fe3d08dd00a526850568d542ff9de9bbc2a09a791da3c334f3213d8d0bbbca65"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==4.56.0"
         },
         "twine": {
@@ -489,6 +532,7 @@
                 "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
                 "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.2"
         },
         "virtualenv": {
@@ -496,6 +540,7 @@
                 "sha256:0c111a2236b191422b37fe8c28b8c828ced39aab4bf5627fa5c331aeffb570d9",
                 "sha256:14b34341e742bdca219e10708198e704e8a7064dd32f474fc16aca68ac53a306"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.1"
         },
         "webencodings": {

--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -59,14 +59,14 @@ class SuperAppSearchModel(models.Model):
         """Get the App Search client."""
         return get_api_v1_client()
 
-    def serialise_for_appsearch(self):
-        pass
-
     def get_appsearch_document_id(self):
         """Get the unique document ID."""
         return "{}_{}".format(type(self).__name__, self.pk)
 
     def index_to_appsearch(self, update_only=False):
+        pass
+
+    def serialise_for_appsearch(self):
         pass
 
     def delete_from_appsearch(self):
@@ -126,7 +126,7 @@ class AppSearchModel(SuperAppSearchModel):
             )
 
 
-class AppSearchMultiEngineModel(models.Model):
+class AppSearchMultiEngineModel(SuperAppSearchModel):
     class Meta:
         """Meta options for the app search model."""
 
@@ -139,3 +139,14 @@ class AppSearchMultiEngineModel(models.Model):
     @classmethod
     def get_appsearch_serialiser_engine_pairs(cls):
         return cls.AppsearchMeta.appsearch_serialiser_engine_pairs
+
+    def index_to_appsearch(self, update_only=False):
+        pass
+
+    def serialise_for_appsearch(self):
+        "Serialise the instance for appsearch."""
+        _pairs = self.get_appsearch_serialiser_engine_pairs()
+        return [serialiser(self).data for (serialiser, _) in _pairs]
+
+    def delete_from_appsearch(self):
+        pass

--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -46,7 +46,7 @@ class AppSearchQuerySet(models.QuerySet):
                         )
 
 
-class SuperAppSearchModel(models.Model):
+class BaseAppSearchModel(models.Model):
     objects = AppSearchQuerySet.as_manager()
 
     class Meta:
@@ -98,7 +98,7 @@ class SuperAppSearchModel(models.Model):
                     in self.get_appsearch_serialiser_engine_pairs()]
 
 
-class AppSearchModel(SuperAppSearchModel):
+class AppSearchModel(BaseAppSearchModel):
     """A model that integrates with Elastic App Search."""
 
     class Meta:
@@ -131,7 +131,7 @@ class AppSearchModel(SuperAppSearchModel):
         cls.AppsearchMeta.appsearch_engine_name = engine_name
 
 
-class AppSearchMultiEngineModel(SuperAppSearchModel):
+class AppSearchMultiEngineModel(BaseAppSearchModel):
     class Meta:
         """Meta options for the app search model."""
 

--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -77,7 +77,6 @@ class BaseAppSearchModel(models.Model):
             )
 
     def _serialise_for_appsearch(self, engine_name=None):
-        """Serialise the instance for appsearch."""
         _pairs = self.get_appsearch_serialiser_engine_pairs()
         if engine_name is not None:
             _pairs = [pair for pair in _pairs if pair[1] == engine_name]
@@ -85,13 +84,11 @@ class BaseAppSearchModel(models.Model):
         return [serialiser(self).data for (serialiser, _) in _pairs]
 
     def _index_to_appsearch(self, update_only=False):
-        """Index the object to appsearch."""
         if apps.get_app_config("django_elastic_appsearch").enabled:
             return [self._index_to_engine(engine_name, update_only) for (_, engine_name)
                     in self.get_appsearch_serialiser_engine_pairs()]
 
     def _delete_from_appsearch(self):
-        """Delete the object from appsearch."""
         if apps.get_app_config("django_elastic_appsearch").enabled:
             return [self._destroy_document(engine_name) for (_, engine_name)
                     in self.get_appsearch_serialiser_engine_pairs()]
@@ -130,13 +127,16 @@ class AppSearchModel(BaseAppSearchModel):
         cls.AppsearchMeta.appsearch_engine_name = engine_name
 
     def serialise_for_appsearch(self, engine_name=None):
-        return super()._serialise_for_appsearch(engine_name=engine_name)[0]
+        """Serialise the instance for appsearch."""
+        return super()._serialise_for_appsearch(engine_name=(engine_name or self.get_appsearch_engine_name()))[0]
 
     def index_to_appsearch(self, update_only=False):
+        """Index the object to appsearch."""
         response = super()._index_to_appsearch(update_only=update_only)
         return response[0] if response else None
 
     def delete_from_appsearch(self):
+        """Delete the object from appsearch."""
         response = super()._delete_from_appsearch()
         return response[0] if response else None
 
@@ -156,10 +156,13 @@ class AppSearchMultiEngineModel(BaseAppSearchModel):
         return cls.AppsearchMeta.appsearch_serialiser_engine_pairs
 
     def serialise_for_appsearch(self, engine_name=None):
+        """Serialise the instance for appsearch."""
         return super()._serialise_for_appsearch(engine_name=engine_name)
 
     def index_to_appsearch(self, update_only=False):
+        """Index the object to appsearch."""
         return super()._index_to_appsearch(update_only=update_only)
 
     def delete_from_appsearch(self):
+        """Delete the object from appsearch."""
         return super()._delete_from_appsearch()

--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -47,6 +47,12 @@ class AppSearchQuerySet(models.QuerySet):
 
 
 class BaseAppSearchModel(models.Model):
+    """
+    Base class for AppSearchModel and AppSearchMultiEngineModel.
+
+    Implements operations that interact with app search for both.
+    """
+
     objects = AppSearchQuerySet.as_manager()
 
     class Meta:
@@ -114,6 +120,13 @@ class AppSearchModel(BaseAppSearchModel):
 
     @classmethod
     def get_appsearch_serialiser_engine_pairs(cls):
+        """
+        Get the serialisers and engines.
+
+        Returns:
+        list of (class, string): List of pairs of app search serialisers and engine names
+            to be used together.
+        """
         return [(cls.get_appsearch_serialiser_class(), cls.get_appsearch_engine_name())]
 
     @classmethod
@@ -142,6 +155,8 @@ class AppSearchModel(BaseAppSearchModel):
 
 
 class AppSearchMultiEngineModel(BaseAppSearchModel):
+    """A model that integrates with multiple Elastic App Search engines."""
+
     class Meta:
         """Meta options for the app search model."""
 
@@ -149,10 +164,24 @@ class AppSearchMultiEngineModel(BaseAppSearchModel):
 
     @classmethod
     def set_appsearch_serialiser_engine_pairs(cls, pairs):
+        """
+        Set the serialisers and engines.
+
+        Args:
+            pairs (list of (class, string)): List of pairs of app search serialisers and engine names
+            to be used together.
+        """
         cls.AppsearchMeta.appsearch_serialiser_engine_pairs = pairs
 
     @classmethod
     def get_appsearch_serialiser_engine_pairs(cls):
+        """
+        Get the serialisers and engines.
+
+        Returns:
+        list of (class, string): List of pairs of app search serialisers and engine names
+            to be used together.
+        """
         return cls.AppsearchMeta.appsearch_serialiser_engine_pairs
 
     def serialise_for_appsearch(self, engine_name=None):

--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -132,4 +132,10 @@ class AppSearchMultiEngineModel(models.Model):
 
         abstract = True
 
-    pass
+    @classmethod
+    def set_appsearch_serialiser_engine_pairs(cls, pairs):
+        cls.AppsearchMeta.appsearch_serialiser_engine_pairs = pairs
+
+    @classmethod
+    def get_appsearch_serialiser_engine_pairs(cls):
+        return cls.AppsearchMeta.appsearch_serialiser_engine_pairs

--- a/django_elastic_appsearch/slicer.py
+++ b/django_elastic_appsearch/slicer.py
@@ -2,8 +2,7 @@
 
 
 def slice_queryset(queryset, chunk_size):
-    """ Slice a queryset into chunks. """
-
+    """Slice a queryset into chunks."""
     start_pk = 0
     queryset = queryset.order_by('pk')
 

--- a/django_elastic_appsearch/test.py
+++ b/django_elastic_appsearch/test.py
@@ -51,7 +51,7 @@ class MockedAppSearchTestCase:
     """
 
     def setUp(self, *args, **kwargs):
-        """Setup app search mocks."""
+        """Initialise app search mocks."""
         queryset_class = kwargs.get('queryset_class', 'django_elastic_appsearch.orm.AppSearchQuerySet.')
 
         queryset_index_to_appsearch = patch(
@@ -82,25 +82,25 @@ class MockedAppSearchTestCase:
         super().setUp()
 
     def assertAppSearchModelIndexCallCount(self, call_count):
-        """Check the call count on `BaseAppSearchModel._index_to_appsearch`"""
+        """Check the call count on `BaseAppSearchModel._index_to_appsearch`."""
         self.assertEqual(self.model_index_to_appsearch.call_count, call_count)
 
     def assertAppSearchModelDeleteCallCount(self, call_count):
-        """Check the call count on `BaseAppSearchModel._delete_from_appsearch`"""
+        """Check the call count on `BaseAppSearchModel._delete_from_appsearch`."""
         self.assertEqual(
             self.model_delete_from_appsearch.call_count,
             call_count
         )
 
     def assertAppSearchQuerySetIndexCallCount(self, call_count):
-        """Check the call count on `AppSearchQueryset.index_to_appsearch`"""
+        """Check the call count on `AppSearchQueryset.index_to_appsearch`."""
         self.assertEqual(
             self.queryset_index_to_appsearch.call_count,
             call_count
         )
 
     def assertAppSearchQuerySetDeleteCallCount(self, call_count):
-        """Check the call count on `AppSearchQueryset.delete_from_appsearch`"""
+        """Check the call count on `AppSearchQueryset.delete_from_appsearch`."""
         self.assertEqual(
             self.queryset_delete_from_appsearch.call_count,
             call_count

--- a/django_elastic_appsearch/test.py
+++ b/django_elastic_appsearch/test.py
@@ -62,10 +62,10 @@ class MockedAppSearchTestCase:
         )
 
         model_index_to_appsearch = patch(
-            'django_elastic_appsearch.orm.AppSearchModel.index_to_appsearch'
+            'django_elastic_appsearch.orm.BaseAppSearchModel._index_to_appsearch'
         )
         model_delete_from_appsearch = patch(
-            'django_elastic_appsearch.orm.AppSearchModel.delete_from_appsearch'
+            'django_elastic_appsearch.orm.BaseAppSearchModel._delete_from_appsearch'
         )
 
         self.queryset_index_to_appsearch = queryset_index_to_appsearch.start()

--- a/django_elastic_appsearch/test.py
+++ b/django_elastic_appsearch/test.py
@@ -82,11 +82,11 @@ class MockedAppSearchTestCase:
         super().setUp()
 
     def assertAppSearchModelIndexCallCount(self, call_count):
-        """Check the call count on `AppSearchModel.index_to_appsearch`"""
+        """Check the call count on `BaseAppSearchModel._index_to_appsearch`"""
         self.assertEqual(self.model_index_to_appsearch.call_count, call_count)
 
     def assertAppSearchModelDeleteCallCount(self, call_count):
-        """Check the call count on `AppSearchModel.delete_from_appsearch`"""
+        """Check the call count on `BaseAppSearchModel._delete_from_appsearch`"""
         self.assertEqual(
             self.model_delete_from_appsearch.call_count,
             call_count

--- a/example/models.py
+++ b/example/models.py
@@ -19,11 +19,11 @@ class Car(AppSearchModel):
     year_manufactured = models.DateTimeField()
 
 
-class MultipleEngineCar(AppSearchMultiEngineModel):
-    """A car."""
+class Truck(AppSearchMultiEngineModel):
+    """A truck."""
 
     class AppsearchMeta:
-        appsearch_serialiser_engine_pairs = [(CarSerialiser, "cars")]
+        appsearch_serialiser_engine_pairs = [(CarSerialiser, "trucks")]
 
     make = models.TextField()
     model = models.TextField()
@@ -32,7 +32,8 @@ class MultipleEngineCar(AppSearchMultiEngineModel):
 
 class Bus(Car):
     """A bus"""
+
     class AppsearchMeta:
-        appsearch_engine_name = 'bus'
+        appsearch_engine_name = "bus"
 
     objects = CustomQuerySet.as_manager()

--- a/example/models.py
+++ b/example/models.py
@@ -1,7 +1,7 @@
 """Example Django app models."""
 
 from django.db import models
-from django_elastic_appsearch.orm import AppSearchModel
+from django_elastic_appsearch.orm import AppSearchModel, AppSearchMultiEngineModel
 
 from example.serialisers import CarSerialiser
 from example.querysets import CustomQuerySet
@@ -13,6 +13,17 @@ class Car(AppSearchModel):
     class AppsearchMeta:
         appsearch_engine_name = 'cars'
         appsearch_serialiser_class = CarSerialiser
+
+    make = models.TextField()
+    model = models.TextField()
+    year_manufactured = models.DateTimeField()
+
+
+class MultipleEngineCar(AppSearchMultiEngineModel):
+    """A car."""
+
+    class AppsearchMeta:
+        appsearch_serialiser_engine_pairs = [(CarSerialiser, "cars")]
 
     make = models.TextField()
     model = models.TextField()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for django_elastic_appsearch."""

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,7 +9,7 @@ class BaseElasticAppSearchClientTestCase(TestCase):
     """Base Elastic App Search Client Test case."""
 
     def setUp(self):
-        """Setup the patches."""
+        """Initialise the patches."""
         super().setUp()
         client_index = patch('elastic_app_search.Client.index_documents')
         client_update = patch('elastic_app_search.Client.update_documents')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8
+"""Settings module for django_elastic_appsearch."""
 from __future__ import unicode_literals, absolute_import
 
 import django

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -6,7 +6,7 @@
 from django.utils import timezone
 from django_elastic_appsearch import serialisers
 
-from example.models import Car, MultipleEngineCar
+from example.models import Car, Truck
 from example.serialisers import CarSerialiser
 
 from .base import BaseElasticAppSearchClientTestCase
@@ -95,41 +95,102 @@ class TestORM(BaseElasticAppSearchClientTestCase):
         original_engine_name = Car.get_appsearch_engine_name()
 
         # Set a new app search engine name
-        Car.set_appsearch_engine_name('test_cars')
+        Car.set_appsearch_engine_name("test_cars")
 
         # Test if its set successfully
         engine_name = Car.get_appsearch_engine_name()
-        self.assertEqual(engine_name, 'test_cars')
+        self.assertEqual(engine_name, "test_cars")
 
         # Reset it back to the original
         Car.set_appsearch_engine_name(original_engine_name)
 
+    def test_serialise_for_appsearch(self):
+        car = Car.objects.first()
+        self.assertEqual('Car_1', car.serialise_for_appsearch()['id'])
+
 
 class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
+
+    class TestSerialiserClass(serialisers.AppSearchSerialiser):
+        model = serialisers.Field()
+
+    class OtherSerialiserClass(serialisers.AppSearchSerialiser):
+        make = serialisers.Field()
+
+    def setUp(self):
+        """Setup the patches and test data."""
+        super().setUp()
+        # Create 22 trucks
+        for i in range(0, 22):
+            timezone_now = timezone.now()
+            # Create a truck
+            truck = Truck(
+                make="Make {}".format(i),
+                model="Model {}".format(i),
+                year_manufactured=timezone_now,
+            )
+            truck.save()
+        
+        # Set the engines and serialisers on the Truck model.
+        pairs = [
+            (TestMultipleEngineModel.TestSerialiserClass, "test_cars"),
+            (TestMultipleEngineModel.OtherSerialiserClass, "other_cars"),
+        ]
+        Truck.set_appsearch_serialiser_engine_pairs(pairs)
+
     def test_set_multiple_serialiser_engine_pairs(self):
         """Test classmethod to set serialiser and engine pairs"""
 
-        # Define a test serialiser class.
-        class TestSerialiserClass(serialisers.AppSearchSerialiser):
-            test_field = serialisers.Field()
-
-        class OtherSerialiserClass(serialisers.AppSearchSerialiser):
-            other_field = serialisers.Field()
-
-        # Set the new serialiser class to the MultipleEngineCar model.
-        pairs = [
-            (TestSerialiserClass, "test_cars"),
-            (OtherSerialiserClass, "other_cars"),
-        ]
-        MultipleEngineCar.set_appsearch_serialiser_engine_pairs(pairs)
-
         # Test if its set successfully
-        pairs = MultipleEngineCar.get_appsearch_serialiser_engine_pairs()
-        self.assertEqual(pairs[0][0], TestSerialiserClass)
+        pairs = Truck.get_appsearch_serialiser_engine_pairs()
+        self.assertEqual(pairs[0][0], TestMultipleEngineModel.TestSerialiserClass)
         self.assertEqual(pairs[0][1], "test_cars")
-        self.assertEqual(pairs[1][0], OtherSerialiserClass)
+        self.assertEqual(pairs[1][0], TestMultipleEngineModel.OtherSerialiserClass)
         self.assertEqual(pairs[1][1], "other_cars")
 
-    def test_indexing(self):
-        """ One, none and multiple """
-        pass
+    def test_serialise_for_appsearch(self):
+        truck = Truck.objects.first().serialise_for_appsearch()
+        self.assertEqual({'id': 'Truck_1', 'object_type': 'Truck', 'model': 'Model 0'}, truck[0])
+        self.assertEqual({'id': 'Truck_1', 'object_type': 'Truck', 'make': 'Make 0'}, truck[1])
+
+    def test_model_object_index(self):
+        """Test indexing a model object to appsearch."""
+        truck = Truck.objects.first()
+        truck.index_to_appsearch()
+        self.assertEqual(self.client_index.call_count, 2)
+
+    def test_model_object_update(self):
+        """Test indexing a model object to appsearch as an update operation."""
+        truck = Truck.objects.first()
+        truck.index_to_appsearch(update_only=True)
+        self.assertEqual(self.client_update.call_count, 2)
+
+    def test_model_object_delete(self):
+        """Test deleting a model object from appsearch."""
+        truck = Truck.objects.first()
+        truck.delete_from_appsearch()
+        self.assertEqual(self.client_destroy.call_count, 2)
+
+    def test_queryset_index(self):
+        """Test indexing a queryset to appsearch."""
+        truck = Truck.objects.all()
+        truck.index_to_appsearch()
+        # Note that the app search chunk size is set to 5 in `tests.settings`
+        # Therefore you should see 5 calls to cover 22 documents
+        self.assertEqual(self.client_index.call_count, 10)
+
+    def test_queryset_update(self):
+        """Test indexing a queryset to appsearch as an update operation."""
+        truck = Truck.objects.all()
+        truck.index_to_appsearch(update_only=True)
+        # Note that the app search chunk size is set to 5 in `tests.settings`
+        # Therefore you should see 5 calls to cover 22 documents
+        self.assertEqual(self.client_update.call_count, 10)
+
+    def test_queryset_delete(self):
+        """Test deleting a queryset from appsearch."""
+        truck = Truck.objects.all()
+        truck.delete_from_appsearch()
+        # Note that the app search chunk size is set to 5 in `tests.settings`
+        # Therefore you should see 5 calls to cover 22 documents
+        self.assertEqual(self.client_destroy.call_count, 10)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -106,7 +106,7 @@ class TestORM(BaseElasticAppSearchClientTestCase):
 
     def test_serialise_for_appsearch(self):
         car = Car.objects.first()
-        self.assertEqual('Car_1', car.serialise_for_appsearch()['id'])
+        self.assertEqual('Car_1', car.serialise_for_appsearch()[0]['id'])
 
 
 class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -6,7 +6,7 @@
 from django.utils import timezone
 from django_elastic_appsearch import serialisers
 
-from example.models import Car
+from example.models import Car, MultipleEngineCar
 from example.serialisers import CarSerialiser
 
 from .base import BaseElasticAppSearchClientTestCase
@@ -103,3 +103,33 @@ class TestORM(BaseElasticAppSearchClientTestCase):
 
         # Reset it back to the original
         Car.set_appsearch_engine_name(original_engine_name)
+
+
+class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
+    def test_set_multiple_serialiser_engine_pairs(self):
+        """Test classmethod to set serialiser and engine pairs"""
+
+        # Define a test serialiser class.
+        class TestSerialiserClass(serialisers.AppSearchSerialiser):
+            test_field = serialisers.Field()
+
+        class OtherSerialiserClass(serialisers.AppSearchSerialiser):
+            other_field = serialisers.Field()
+
+        # Set the new serialiser class to the MultipleEngineCar model.
+        pairs = [
+            (TestSerialiserClass, "test_cars"),
+            (OtherSerialiserClass, "other_cars"),
+        ]
+        MultipleEngineCar.set_appsearch_serialiser_engine_pairs(pairs)
+
+        # Test if its set successfully
+        pairs = MultipleEngineCar.get_appsearch_serialiser_engine_pairs()
+        self.assertEqual(pairs[0][0], TestSerialiserClass)
+        self.assertEqual(pairs[0][1], "test_cars")
+        self.assertEqual(pairs[1][0], OtherSerialiserClass)
+        self.assertEqual(pairs[1][1], "other_cars")
+
+    def test_indexing(self):
+        """ One, none and multiple """
+        pass

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -106,7 +106,7 @@ class TestORM(BaseElasticAppSearchClientTestCase):
 
     def test_serialise_for_appsearch(self):
         car = Car.objects.first()
-        self.assertEqual('Car_1', car.serialise_for_appsearch()[0]['id'])
+        self.assertEqual('Car_1', car.serialise_for_appsearch()['id'])
 
 
 class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -176,7 +176,7 @@ class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
         truck = Truck.objects.all()
         truck.index_to_appsearch()
         # Note that the app search chunk size is set to 5 in `tests.settings`
-        # Therefore you should see 5 calls to cover 22 documents
+        # Therefore you should see 5 calls to cover 22 documents, over 2 engines
         self.assertEqual(self.client_index.call_count, 10)
 
     def test_queryset_update(self):
@@ -184,7 +184,7 @@ class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
         truck = Truck.objects.all()
         truck.index_to_appsearch(update_only=True)
         # Note that the app search chunk size is set to 5 in `tests.settings`
-        # Therefore you should see 5 calls to cover 22 documents
+        # Therefore you should see 5 calls to cover 22 documents, over 2 engines
         self.assertEqual(self.client_update.call_count, 10)
 
     def test_queryset_delete(self):
@@ -192,5 +192,5 @@ class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
         truck = Truck.objects.all()
         truck.delete_from_appsearch()
         # Note that the app search chunk size is set to 5 in `tests.settings`
-        # Therefore you should see 5 calls to cover 22 documents
+        # Therefore you should see 5 calls to cover 22 documents, over 2 engines
         self.assertEqual(self.client_destroy.call_count, 10)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -130,7 +130,7 @@ class TestMultipleEngineModel(BaseElasticAppSearchClientTestCase):
                 year_manufactured=timezone_now,
             )
             truck.save()
-        
+
         # Set the engines and serialisers on the Truck model.
         pairs = [
             (TestMultipleEngineModel.TestSerialiserClass, "test_cars"),


### PR DESCRIPTION
Add support for multiple pairs of engines with different serialisers.
As previously discussed the queryset, existing model base class and new model base class have been integrated with an existing application and tested.
This change does not yet include documentation.