### PR TITLE
Return responses

### DIFF
--- a/django_elastic_appsearch/orm.py
+++ b/django_elastic_appsearch/orm.py
@@ -120,6 +120,7 @@ class BaseAppSearchModel(models.Model):
         if apps.get_app_config("django_elastic_appsearch").enabled:
             return [self._index_to_engine(engine_name, update_only) for (_, engine_name)
                     in self.get_appsearch_serialiser_engine_pairs()]
+        return []
 
     def _delete_from_appsearch(self):
         """
@@ -131,6 +132,7 @@ class BaseAppSearchModel(models.Model):
         if apps.get_app_config("django_elastic_appsearch").enabled:
             return [self._destroy_document(engine_name) for (_, engine_name)
                     in self.get_appsearch_serialiser_engine_pairs()]
+        return []
 
 
 class AppSearchModel(BaseAppSearchModel):


### PR DESCRIPTION
Return more responses from app search for more error reporting - specifically with the query set.

I also think it's handy to return an empty list rather than None to avoid the need to explicitly check when iterating over it.