### PR TITLE
Set encoding explicitly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ if sys.argv[-1] == 'tag':
     os.system("git push --tags")
     sys.exit()
 
-readme = open('README.rst').read()
-history = open('HISTORY.rst').read().replace('.. :changelog:', '')
+readme = open('README.rst', encoding='utf-8').read()
+history = open('HISTORY.rst', encoding='utf-8').read().replace('.. :changelog:', '')
 
 setup(
     name='django_elastic_appsearch',


### PR DESCRIPTION
This wouldn't have worked on windows if we had non ASCII characters in the README or history, see
https://www.python.org/dev/peps/pep-0597/#using-the-default-encoding-is-a-common-mistake