### PR TITLE
Remove dependabot badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,9 +20,6 @@ Django Elastic App Search
 .. image:: https://github.com/corrosivekid/django_elastic_appsearch/workflows/Dependencies/badge.svg
     :target: https://github.com/CorrosiveKid/django_elastic_appsearch/actions?query=workflow%3ADependencies
 
-.. image:: https://badgen.net/dependabot/CorrosiveKid/django_elastic_appsearch?icon=dependabot
-    :target: https://dependabot.com/
-
 Integrate your Django Project with Elastic App Search with ease.
 
 Documentation


### PR DESCRIPTION
Dependabot badge on the README was only supported before Github native dependabot. Removing it for now until github implements their own badge.